### PR TITLE
Use tags to determine which credentials to use

### DIFF
--- a/lib/connection.rb
+++ b/lib/connection.rb
@@ -73,8 +73,16 @@ module RabbitExample
     end
 
     def amqp_credentials
-      protocols = vcap_services['p-rabbitmq'].first['credentials']['protocols']
+      protocols = extract_credentials(vcap_services)['protocols']
       protocols['amqp+ssl'] || protocols['amqp']
+    end
+
+    def extract_credentials(vcap_services)
+      vcap_services.each do |service_key, service|
+        service.each do |element|
+          return element["credentials"] if element["tags"].include?("rabbitmq")
+        end
+      end
     end
 
     def puts_success(msg)

--- a/lib/store.rb
+++ b/lib/store.rb
@@ -53,8 +53,16 @@ module RabbitExample
     end
 
     def amqp_credentials
-      protocols = vcap_services['p-rabbitmq'].first['credentials']['protocols']
+      protocols = extract_credentials(vcap_services)['protocols']
       protocols['amqp+ssl'] || protocols['amqp']
+    end
+
+    def extract_credentials(vcap_services)
+      vcap_services.each do |service_key, service|
+        service.each do |element|
+          return element["credentials"] if element["tags"].include?("rabbitmq")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- When rabbit service catalog advertises as something other than p-rabbitmq, this was failing

[#108585608]

Signed-off-by: William Martin wmartin@pivotal.io
